### PR TITLE
Add more settings to pgPlugin

### DIFF
--- a/src/plugins/pgPlugin.test.tsx
+++ b/src/plugins/pgPlugin.test.tsx
@@ -237,7 +237,7 @@ describe("pgPlugin", () => {
       const mockSetUser = jest.fn();
       const mockSetPassword = jest.fn();
       const mockSetPort = jest.fn();
-      const { getByLabelText, getByTestId } = render(
+      const { getByLabelText, getByTestId, getByText } = render(
         React.createElement(pgPlugin.component, {
           database: "mydb",
           query: "SELECT * FROM users",
@@ -253,6 +253,9 @@ describe("pgPlugin", () => {
           setPort: mockSetPort,
         })
       );
+
+      const showSettingsButton = getByText("Show Settings");
+      fireEvent.click(showSettingsButton);
 
       const databaseInput = getByLabelText("Database");
       expect(databaseInput).toHaveValue("mydb");

--- a/src/plugins/pgPlugin.test.tsx
+++ b/src/plugins/pgPlugin.test.tsx
@@ -36,6 +36,10 @@ describe("pgPlugin", () => {
         type: "pg",
         database: "mydb",
         query: "SELECT * FROM users",
+        hostname: "",
+        user: "",
+        password: "",
+        port: "",
       });
     });
 
@@ -55,6 +59,10 @@ describe("pgPlugin", () => {
         type: "pg",
         database: "",
         query: "SELECT * FROM users",
+        hostname: "",
+        user: "",
+        password: "",
+        port: "",
       });
     });
 
@@ -74,6 +82,43 @@ describe("pgPlugin", () => {
         type: "pg",
         database: "mydb",
         query: "",
+        hostname: "",
+        user: "",
+        password: "",
+        port: "",
+      });
+    });
+
+    it("should parse a pg command with hostname, user, password, and port", () => {
+      const command: CommandNode = {
+        type: "Command",
+        name: { text: "pg", type: "Word" },
+        suffix: [
+          { text: "-d", type: "Word" },
+          { text: "mydb", type: "Word" },
+          { text: "-c", type: "Word" },
+          { text: "SELECT * FROM users", type: "Word" },
+          { text: "-h", type: "Word" },
+          { text: "localhost", type: "Word" },
+          { text: "-U", type: "Word" },
+          { text: "user", type: "Word" },
+          { text: "-W", type: "Word" },
+          { text: "password", type: "Word" },
+          { text: "-p", type: "Word" },
+          { text: "5432", type: "Word" },
+        ],
+      };
+
+      const result = pgPlugin.parse(command);
+
+      expect(result).toEqual({
+        type: "pg",
+        database: "mydb",
+        query: "SELECT * FROM users",
+        hostname: "localhost",
+        user: "user",
+        password: "password",
+        port: "5432",
       });
     });
   });
@@ -84,6 +129,10 @@ describe("pgPlugin", () => {
         type: "pg",
         database: "mydb",
         query: "SELECT * FROM users",
+        hostname: "",
+        user: "",
+        password: "",
+        port: "",
       };
 
       const result = pgPlugin.compile(module);
@@ -105,6 +154,10 @@ describe("pgPlugin", () => {
         type: "pg",
         database: "",
         query: "SELECT * FROM users",
+        hostname: "",
+        user: "",
+        password: "",
+        port: "",
       };
 
       const result = pgPlugin.compile(module);
@@ -124,6 +177,10 @@ describe("pgPlugin", () => {
         type: "pg",
         database: "mydb",
         query: "",
+        hostname: "",
+        user: "",
+        password: "",
+        port: "",
       };
 
       const result = pgPlugin.compile(module);
@@ -137,18 +194,63 @@ describe("pgPlugin", () => {
         ],
       });
     });
+
+    it("should compile a pg command with hostname, user, password, and port", () => {
+      const module = {
+        type: "pg",
+        database: "mydb",
+        query: "SELECT * FROM users",
+        hostname: "localhost",
+        user: "user",
+        password: "password",
+        port: "5432",
+      };
+
+      const result = pgPlugin.compile(module);
+
+      expect(result).toEqual({
+        type: "Command",
+        name: { text: "pg", type: "Word" },
+        suffix: [
+          { type: "Word", text: "-d" },
+          { type: "Word", text: "mydb" },
+          { type: "Word", text: "-c" },
+          { type: "Word", text: "SELECT * FROM users" },
+          { type: "Word", text: "-h" },
+          { type: "Word", text: "localhost" },
+          { type: "Word", text: "-U" },
+          { type: "Word", text: "user" },
+          { type: "Word", text: "-W" },
+          { type: "Word", text: "password" },
+          { type: "Word", text: "-p" },
+          { type: "Word", text: "5432" },
+        ],
+      });
+    });
   });
 
   describe("component", () => {
     it("should render and update correctly", () => {
       const mockSetDatabase = jest.fn();
       const mockSetQuery = jest.fn();
+      const mockSetHostname = jest.fn();
+      const mockSetUser = jest.fn();
+      const mockSetPassword = jest.fn();
+      const mockSetPort = jest.fn();
       const { getByLabelText, getByTestId } = render(
         React.createElement(pgPlugin.component, {
           database: "mydb",
           query: "SELECT * FROM users",
+          hostname: "localhost",
+          user: "user",
+          password: "password",
+          port: "5432",
           setDatabase: mockSetDatabase,
           setQuery: mockSetQuery,
+          setHostname: mockSetHostname,
+          setUser: mockSetUser,
+          setPassword: mockSetPassword,
+          setPort: mockSetPort,
         })
       );
 
@@ -158,6 +260,18 @@ describe("pgPlugin", () => {
       const queryEditor = getByTestId("query-editor");
       expect(queryEditor).toHaveValue("SELECT * FROM users");
 
+      const hostnameInput = getByLabelText("Hostname");
+      expect(hostnameInput).toHaveValue("localhost");
+
+      const userInput = getByLabelText("User");
+      expect(userInput).toHaveValue("user");
+
+      const passwordInput = getByLabelText("Password");
+      expect(passwordInput).toHaveValue("password");
+
+      const portInput = getByLabelText("Port");
+      expect(portInput).toHaveValue("5432");
+
       fireEvent.change(databaseInput, { target: { value: "newdb" } });
       expect(mockSetDatabase).toHaveBeenCalledWith("newdb");
 
@@ -165,6 +279,18 @@ describe("pgPlugin", () => {
         target: { value: "SELECT * FROM products" },
       });
       expect(mockSetQuery).toHaveBeenCalledWith("SELECT * FROM products");
+
+      fireEvent.change(hostnameInput, { target: { value: "newhost" } });
+      expect(mockSetHostname).toHaveBeenCalledWith("newhost");
+
+      fireEvent.change(userInput, { target: { value: "newuser" } });
+      expect(mockSetUser).toHaveBeenCalledWith("newuser");
+
+      fireEvent.change(passwordInput, { target: { value: "newpassword" } });
+      expect(mockSetPassword).toHaveBeenCalledWith("newpassword");
+
+      fireEvent.change(portInput, { target: { value: "1234" } });
+      expect(mockSetPort).toHaveBeenCalledWith("1234");
     });
   });
 });

--- a/src/plugins/pgPlugin.tsx
+++ b/src/plugins/pgPlugin.tsx
@@ -7,18 +7,34 @@ interface PgModuleType extends ModuleType {
   type: "pg";
   database: string;
   query: string;
+  hostname: string;
+  user: string;
+  password: string;
+  port: string;
 }
 
 interface PgComponentProps extends PgModuleType {
   setDatabase: (value: string) => void;
   setQuery: (value: string) => void;
+  setHostname: (value: string) => void;
+  setUser: (value: string) => void;
+  setPassword: (value: string) => void;
+  setPort: (value: string) => void;
 }
 
 const PgComponent: React.FC<PgComponentProps> = ({
   database,
   query,
+  hostname,
+  user,
+  password,
+  port,
   setDatabase,
   setQuery,
+  setHostname,
+  setUser,
+  setPassword,
+  setPort,
 }) => (
   <>
     <h2 className="text-lg font-semibold mb-2">pg</h2>
@@ -36,6 +52,70 @@ const PgComponent: React.FC<PgComponentProps> = ({
         onChange={(e) => setDatabase(e.target.value)}
         className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2"
         placeholder="Enter database name..."
+      />
+    </div>
+    <div className="mb-2">
+      <label
+        htmlFor="hostname-input"
+        className="block text-sm font-medium text-gray-700"
+      >
+        Hostname
+      </label>
+      <input
+        id="hostname-input"
+        type="text"
+        value={hostname}
+        onChange={(e) => setHostname(e.target.value)}
+        className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2"
+        placeholder="Enter hostname..."
+      />
+    </div>
+    <div className="mb-2">
+      <label
+        htmlFor="user-input"
+        className="block text-sm font-medium text-gray-700"
+      >
+        User
+      </label>
+      <input
+        id="user-input"
+        type="text"
+        value={user}
+        onChange={(e) => setUser(e.target.value)}
+        className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2"
+        placeholder="Enter user..."
+      />
+    </div>
+    <div className="mb-2">
+      <label
+        htmlFor="password-input"
+        className="block text-sm font-medium text-gray-700"
+      >
+        Password
+      </label>
+      <input
+        id="password-input"
+        type="password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2"
+        placeholder="Enter password..."
+      />
+    </div>
+    <div className="mb-2">
+      <label
+        htmlFor="port-input"
+        className="block text-sm font-medium text-gray-700"
+      >
+        Port
+      </label>
+      <input
+        id="port-input"
+        type="text"
+        value={port}
+        onChange={(e) => setPort(e.target.value)}
+        className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2"
+        placeholder="Enter port..."
       />
     </div>
     <div className="h-full">
@@ -60,6 +140,10 @@ export const pgPlugin: Plugin = {
   parse: (command: CommandNode): PgModuleType => {
     let query = "";
     let database = "";
+    let hostname = "";
+    let user = "";
+    let password = "";
+    let port = "";
     if (command.suffix) {
       const dArgIndex = command.suffix.findIndex(
         (arg: WordNode | RedirectNode) => arg.text === "-d"
@@ -73,11 +157,39 @@ export const pgPlugin: Plugin = {
       if (cArgIndex !== -1 && cArgIndex + 1 < command.suffix.length) {
         query = command.suffix[cArgIndex + 1].text || "";
       }
+      const hArgIndex = command.suffix.findIndex(
+        (arg: WordNode | RedirectNode) => arg.text === "-h"
+      );
+      if (hArgIndex !== -1 && hArgIndex + 1 < command.suffix.length) {
+        hostname = command.suffix[hArgIndex + 1].text || "";
+      }
+      const uArgIndex = command.suffix.findIndex(
+        (arg: WordNode | RedirectNode) => arg.text === "-U"
+      );
+      if (uArgIndex !== -1 && uArgIndex + 1 < command.suffix.length) {
+        user = command.suffix[uArgIndex + 1].text || "";
+      }
+      const pArgIndex = command.suffix.findIndex(
+        (arg: WordNode | RedirectNode) => arg.text === "-W"
+      );
+      if (pArgIndex !== -1 && pArgIndex + 1 < command.suffix.length) {
+        password = command.suffix[pArgIndex + 1].text || "";
+      }
+      const PArgIndex = command.suffix.findIndex(
+        (arg: WordNode | RedirectNode) => arg.text === "-p"
+      );
+      if (PArgIndex !== -1 && PArgIndex + 1 < command.suffix.length) {
+        port = command.suffix[PArgIndex + 1].text || "";
+      }
     }
     return {
       type: "pg",
       database: database,
       query: query,
+      hostname: hostname,
+      user: user,
+      password: password,
+      port: port,
     };
   },
   component: PgComponent,
@@ -97,6 +209,30 @@ export const pgPlugin: Plugin = {
           ? [
               { type: "Word", text: "-c" } as WordNode,
               { type: "Word", text: pgModule.query } as WordNode,
+            ]
+          : []),
+        ...(pgModule.hostname
+          ? [
+              { type: "Word", text: "-h" } as WordNode,
+              { type: "Word", text: pgModule.hostname } as WordNode,
+            ]
+          : []),
+        ...(pgModule.user
+          ? [
+              { type: "Word", text: "-U" } as WordNode,
+              { type: "Word", text: pgModule.user } as WordNode,
+            ]
+          : []),
+        ...(pgModule.password
+          ? [
+              { type: "Word", text: "-W" } as WordNode,
+              { type: "Word", text: pgModule.password } as WordNode,
+            ]
+          : []),
+        ...(pgModule.port
+          ? [
+              { type: "Word", text: "-p" } as WordNode,
+              { type: "Word", text: pgModule.port } as WordNode,
             ]
           : []),
       ],

--- a/src/plugins/pgPlugin.tsx
+++ b/src/plugins/pgPlugin.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import CodeEditor from "../codeEditor";
 import { Plugin } from "../Plugins";
 import { ModuleType, RedirectNode, CommandNode, WordNode } from "../types";
@@ -35,104 +35,118 @@ const PgComponent: React.FC<PgComponentProps> = ({
   setUser,
   setPassword,
   setPort,
-}) => (
-  <>
-    <h2 className="text-lg font-semibold mb-2">pg</h2>
-    <div className="mb-2">
-      <label
-        htmlFor="database-input"
-        className="block text-sm font-medium text-gray-700"
+}) => {
+  const [showSettings, setShowSettings] = useState(false);
+
+  return (
+    <>
+      <h2 className="text-lg font-semibold mb-2">pg</h2>
+      <button
+        onClick={() => setShowSettings(!showSettings)}
+        className="mb-2 px-2 py-1 bg-blue-500 text-white rounded hover:bg-blue-600"
       >
-        Database
-      </label>
-      <input
-        id="database-input"
-        type="text"
-        value={database}
-        onChange={(e) => setDatabase(e.target.value)}
-        className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2"
-        placeholder="Enter database name..."
-      />
-    </div>
-    <div className="mb-2">
-      <label
-        htmlFor="hostname-input"
-        className="block text-sm font-medium text-gray-700"
-      >
-        Hostname
-      </label>
-      <input
-        id="hostname-input"
-        type="text"
-        value={hostname}
-        onChange={(e) => setHostname(e.target.value)}
-        className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2"
-        placeholder="Enter hostname..."
-      />
-    </div>
-    <div className="mb-2">
-      <label
-        htmlFor="user-input"
-        className="block text-sm font-medium text-gray-700"
-      >
-        User
-      </label>
-      <input
-        id="user-input"
-        type="text"
-        value={user}
-        onChange={(e) => setUser(e.target.value)}
-        className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2"
-        placeholder="Enter user..."
-      />
-    </div>
-    <div className="mb-2">
-      <label
-        htmlFor="password-input"
-        className="block text-sm font-medium text-gray-700"
-      >
-        Password
-      </label>
-      <input
-        id="password-input"
-        type="password"
-        value={password}
-        onChange={(e) => setPassword(e.target.value)}
-        className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2"
-        placeholder="Enter password..."
-      />
-    </div>
-    <div className="mb-2">
-      <label
-        htmlFor="port-input"
-        className="block text-sm font-medium text-gray-700"
-      >
-        Port
-      </label>
-      <input
-        id="port-input"
-        type="text"
-        value={port}
-        onChange={(e) => setPort(e.target.value)}
-        className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2"
-        placeholder="Enter port..."
-      />
-    </div>
-    <div className="h-full">
-      <label
-        htmlFor="query-editor"
-        className="block text-sm font-medium text-gray-700"
-      >
-        Query
-      </label>
-      <CodeEditor
-        value={query}
-        onChange={setQuery}
-        language="sql"
-      />
-    </div>
-  </>
-);
+        {showSettings ? "Hide Settings" : "Show Settings"}
+      </button>
+      {showSettings && (
+        <>
+          <div className="mb-2">
+            <label
+              htmlFor="database-input"
+              className="block text-sm font-medium text-gray-700"
+            >
+              Database
+            </label>
+            <input
+              id="database-input"
+              type="text"
+              value={database}
+              onChange={(e) => setDatabase(e.target.value)}
+              className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2"
+              placeholder="Enter database name..."
+            />
+          </div>
+          <div className="mb-2">
+            <label
+              htmlFor="hostname-input"
+              className="block text-sm font-medium text-gray-700"
+            >
+              Hostname
+            </label>
+            <input
+              id="hostname-input"
+              type="text"
+              value={hostname}
+              onChange={(e) => setHostname(e.target.value)}
+              className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2"
+              placeholder="Enter hostname..."
+            />
+          </div>
+          <div className="mb-2">
+            <label
+              htmlFor="user-input"
+              className="block text-sm font-medium text-gray-700"
+            >
+              User
+            </label>
+            <input
+              id="user-input"
+              type="text"
+              value={user}
+              onChange={(e) => setUser(e.target.value)}
+              className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2"
+              placeholder="Enter user..."
+            />
+          </div>
+          <div className="mb-2">
+            <label
+              htmlFor="password-input"
+              className="block text-sm font-medium text-gray-700"
+            >
+              Password
+            </label>
+            <input
+              id="password-input"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2"
+              placeholder="Enter password..."
+            />
+          </div>
+          <div className="mb-2">
+            <label
+              htmlFor="port-input"
+              className="block text-sm font-medium text-gray-700"
+            >
+              Port
+            </label>
+            <input
+              id="port-input"
+              type="text"
+              value={port}
+              onChange={(e) => setPort(e.target.value)}
+              className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2"
+              placeholder="Enter port..."
+            />
+          </div>
+        </>
+      )}
+      <div className="h-full">
+        <label
+          htmlFor="query-editor"
+          className="block text-sm font-medium text-gray-700"
+        >
+          Query
+        </label>
+        <CodeEditor
+          value={query}
+          onChange={setQuery}
+          language="sql"
+        />
+      </div>
+    </>
+  );
+};
 
 export const pgPlugin: Plugin = {
   name: "PostgreSQL",


### PR DESCRIPTION
Related to #1

Add support for hostname, user, password, and port parameters to the `pgPlugin`.

* **src/plugins/pgPlugin.tsx**
  - Add input fields for hostname, user, password, and port in the `PgComponent`.
  - Update the `parse` function to extract hostname, user, password, and port parameters from the command.
  - Update the `compile` function to include hostname, user, password, and port parameters in the command.

* **src/plugins/pgPlugin.test.tsx**
  - Add tests for hostname, user, password, and port parameters in the `pgPlugin`.
  - Update existing tests to include hostname, user, password, and port parameters.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/williamcotton/guish/issues/1?shareId=b1a3cd45-2ad7-45b8-ae5c-bace7789ee01).