### PR TITLE
Add postgres schema query to ElectronAPI

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,4 +1,3 @@
-// App.test.tsx
 import React from "react";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom";
@@ -73,6 +72,7 @@ const mockElectronApi: jest.Mocked<ElectronAPI> = {
   openScriptFile: jest.fn(),
   chatCompletionsCreate: jest.fn(),
   getOpenAIStatus: jest.fn(),
+  getPgSchema: jest.fn(),
 };
 
 describe("App", () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,6 +17,7 @@ import fs from "fs";
 import os from "os";
 import { astToCommand } from "./astToCommand";
 import { PipelineNode, ScriptNode } from "./types";
+import { Client } from "pg";
 
 interface Config {
   shell: string;
@@ -369,6 +370,45 @@ const createWindow = () => {
   ipcMain.handle("get-openai-status", () => {
     return isOpenAIEnabled;
   });
+
+  ipcMain.handle(
+    "get-pg-schema",
+    async (
+      _event: IpcMainInvokeEvent,
+      connectionInfo: { user: string; host: string; database: string; password: string; port: number }
+    ) => {
+      const client = new Client(connectionInfo);
+      try {
+        await client.connect();
+        const res = await client.query(`
+          SELECT 
+              t.table_schema,
+              t.table_name,
+              c.column_name,
+              c.data_type
+          FROM 
+              (SELECT table_schema, table_name
+               FROM information_schema.tables
+               WHERE table_type = 'BASE TABLE' 
+               AND table_schema NOT IN ('pg_catalog', 'information_schema')
+              ) AS t
+          JOIN 
+              information_schema.columns AS c 
+          ON 
+              t.table_schema = c.table_schema 
+              AND t.table_name = c.table_name
+          ORDER BY 
+              t.table_schema, t.table_name, c.ordinal_position;
+        `);
+        await client.end();
+        return { success: true, schema: res.rows };
+      } catch (error) {
+        await client.end();
+        console.error("Error querying PostgreSQL schema:", error);
+        return { success: false, error: (error as Error).message };
+      }
+    }
+  );
 };
 
 // This method will be called when Electron has finished

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -51,6 +51,8 @@ const electronApi: ElectronAPI = {
   chatCompletionsCreate: (messages) =>
     ipcRenderer.invoke("chat-completions-create", messages),
   getOpenAIStatus: () => ipcRenderer.invoke("get-openai-status"),
+  getPgSchema: (connectionInfo) =>
+    ipcRenderer.invoke("get-pg-schema", connectionInfo),
 };
 
 contextBridge.exposeInMainWorld("electron", electronApi);

--- a/src/types.ts
+++ b/src/types.ts
@@ -268,6 +268,9 @@ export interface ElectronAPI {
     messages: ChatCompletionCreateParamsBase["messages"]
   ) => Promise<ChatCompletion>;
   getOpenAIStatus: () => Promise<boolean>;
+  getPgSchema: (
+    connectionInfo: { user: string; host: string; database: string; password: string; port: number }
+  ) => Promise<{ success: boolean; schema?: any[]; error?: string }>;
 }
 
 export interface SaveScriptDialogResult {

--- a/src/useFileOperations.test.tsx
+++ b/src/useFileOperations.test.tsx
@@ -35,6 +35,7 @@ const mockElectronApi: jest.Mocked<ElectronAPI> = {
   showDirectoryDialog: jest.fn(),
   chatCompletionsCreate: jest.fn(),
   getOpenAIStatus: jest.fn(),
+  getPgSchema: jest.fn(),
 };
 
 // Mock the UseStoreType

--- a/src/useStore.test.tsx
+++ b/src/useStore.test.tsx
@@ -1,4 +1,3 @@
-// useStore.test.tsx
 import React from "react";
 import { render, fireEvent, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
@@ -30,6 +29,7 @@ const mockElectronApi: jest.Mocked<ElectronAPI> = {
   openScriptFile: jest.fn(),
   chatCompletionsCreate: jest.fn(),
   getOpenAIStatus: jest.fn(),
+  getPgSchema: jest.fn(),
 };
 
 // Create a test component that uses the hook


### PR DESCRIPTION
Related to #3

Add IPC function to query PostgreSQL schema.

* **src/main.ts**
  - Import `Client` from `pg`.
  - Add IPC handler `get-pg-schema` to connect to PostgreSQL, execute the specified query, and return the schema information.
* **src/preload.ts**
  - Add `getPgSchema` function to the ElectronAPI to invoke the `get-pg-schema` IPC handler.
* **src/types.ts**
  - Add `getPgSchema` function definition to the ElectronAPI interface.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/williamcotton/guish/issues/3?shareId=3708c57f-5b64-40a1-837a-89e3f16e1a7e).