### PR TITLE
Refactor AI Assistant code

### DIFF
--- a/src/AiAssistants.ts
+++ b/src/AiAssistants.ts
@@ -1,4 +1,3 @@
-
 import { ElectronAPI } from "./types";
 import { UseStoreType } from "./useStore";
 import { ChatCompletionMessageParam } from "openai/resources/chat/completions";
@@ -8,7 +7,7 @@ import { postgresAssistant } from "./ai-assistants/postgresAssistant";
 
 // Define the Assistant interface
 export interface AiAssistant {
-  (store: UseStoreType, electronApi: ElectronAPI, updatedChatHistory: ChatCompletionMessageParam[]): Promise<void>;
+  (store: UseStoreType, electronApi: ElectronAPI, updatedChatHistory: ChatCompletionMessageParam[]): Promise<ChatCompletionMessageParam[]>;
 }
 
 export class AiAssistants {
@@ -18,10 +17,12 @@ export class AiAssistants {
     this.plugins.push(plugin);
   }
 
-  static async run(store: UseStoreType, electronApi: ElectronAPI, updatedChatHistory: ChatCompletionMessageParam[]): Promise<void> {
+  static async run(store: UseStoreType, electronApi: ElectronAPI, updatedChatHistory: ChatCompletionMessageParam[]): Promise<ChatCompletionMessageParam[]> {
+    let modifiedChatHistory = [...updatedChatHistory];
     for (const plugin of this.plugins) {
-      await plugin(store, electronApi, updatedChatHistory);
+      modifiedChatHistory = await plugin(store, electronApi, modifiedChatHistory);
     }
+    return modifiedChatHistory;
   }
 }
 

--- a/src/AiAssistants.ts
+++ b/src/AiAssistants.ts
@@ -18,9 +18,12 @@ export class AiAssistants {
   }
 
   static async run(store: UseStoreType, electronApi: ElectronAPI, updatedChatHistory: ChatCompletionMessageParam[]): Promise<ChatCompletionMessageParam[]> {
-    let modifiedChatHistory = [...updatedChatHistory];
+    const modifiedChatHistory = [...updatedChatHistory];
     for (const plugin of this.plugins) {
-      modifiedChatHistory = await plugin(store, electronApi, modifiedChatHistory);
+      const pluginResponse = await plugin(store, electronApi, modifiedChatHistory);
+      if (pluginResponse) {
+        modifiedChatHistory.push(...pluginResponse);
+      }
     }
     return modifiedChatHistory;
   }

--- a/src/ai-assistants/postgresAssistant.test.ts
+++ b/src/ai-assistants/postgresAssistant.test.ts
@@ -28,10 +28,10 @@ describe("postgresAssistant", () => {
       ...mockStore.chatHistory,
     ];
 
-    await postgresAssistant(mockStore, mockElectronApi, updatedChatHistory);
+    const result = await postgresAssistant(mockStore, mockElectronApi, updatedChatHistory);
 
     expect(mockElectronApi.getPgSchema).not.toHaveBeenCalled();
-    expect(updatedChatHistory).toEqual(mockStore.chatHistory);
+    expect(result).toEqual(mockStore.chatHistory);
   });
 
   it("should add schema for pg module if not present in chat history", async () => {
@@ -56,7 +56,7 @@ describe("postgresAssistant", () => {
       schema: mockSchema,
     });
 
-    await postgresAssistant(mockStore, mockElectronApi, updatedChatHistory);
+    const result = await postgresAssistant(mockStore, mockElectronApi, updatedChatHistory);
 
     expect(mockElectronApi.getPgSchema).toHaveBeenCalledWith({
       database: "testdb",
@@ -65,7 +65,7 @@ describe("postgresAssistant", () => {
       password: "testpass",
       port: 5432,
     });
-    expect(updatedChatHistory).toEqual([
+    expect(result).toEqual([
       {
         role: "system",
         content: `Postgres schema: ${JSON.stringify(mockSchema)}`,
@@ -105,10 +105,10 @@ describe("postgresAssistant", () => {
       .mockResolvedValueOnce({ success: true, schema: mockSchema1 })
       .mockResolvedValueOnce({ success: true, schema: mockSchema2 });
 
-    await postgresAssistant(mockStore, mockElectronApi, updatedChatHistory);
+    const result = await postgresAssistant(mockStore, mockElectronApi, updatedChatHistory);
 
     expect(mockElectronApi.getPgSchema).toHaveBeenCalledTimes(2);
-    expect(updatedChatHistory).toEqual([
+    expect(result).toEqual([
       {
         role: "system",
         content: `Postgres schema: ${JSON.stringify(
@@ -123,10 +123,10 @@ describe("postgresAssistant", () => {
     mockStore.chatHistory = [];
     const updatedChatHistory: ChatCompletionMessageParam[] = [];
 
-    await postgresAssistant(mockStore, mockElectronApi, updatedChatHistory);
+    const result = await postgresAssistant(mockStore, mockElectronApi, updatedChatHistory);
 
     expect(mockElectronApi.getPgSchema).not.toHaveBeenCalled();
-    expect(updatedChatHistory).toEqual([]);
+    expect(result).toEqual([]);
   });
 
   it("should handle errors when fetching schema", async () => {
@@ -148,9 +148,9 @@ describe("postgresAssistant", () => {
       error: "Database connection failed",
     });
 
-    await postgresAssistant(mockStore, mockElectronApi, updatedChatHistory);
+    const result = await postgresAssistant(mockStore, mockElectronApi, updatedChatHistory);
 
     expect(mockElectronApi.getPgSchema).toHaveBeenCalled();
-    expect(updatedChatHistory).toEqual([]);
+    expect(result).toEqual([]);
   });
 });

--- a/src/ai-assistants/postgresAssistant.ts
+++ b/src/ai-assistants/postgresAssistant.ts
@@ -3,12 +3,11 @@ import { PgModuleType } from "../plugins/pgPlugin";
 import { ElectronAPI } from "../types";
 import { ChatCompletionMessageParam } from "openai/resources/chat/completions";
 
-
 export const postgresAssistant = async (
   store: UseStoreType,
   electronApi: ElectronAPI,
   updatedChatHistory: ChatCompletionMessageParam[]
-) => {
+): Promise<ChatCompletionMessageParam[]> => {
   const schemaNotAdded = !store.chatHistory.some(
     (msg) => msg.role === "system" && msg.content.includes("Postgres schema")
   );
@@ -42,4 +41,6 @@ export const postgresAssistant = async (
       updatedChatHistory.push(pgMessage);
     }
   }
+
+  return updatedChatHistory;
 };

--- a/src/useAIAssistant.ts
+++ b/src/useAIAssistant.ts
@@ -37,11 +37,11 @@ export const useAIAssistant = (store: UseStoreType, electronApi: ElectronAPI) =>
       newMessage,
     ];
 
-    await AiAssistants.run(store, electronApi, updatedChatHistory);
+    const updatedAssistedChatHistory = await AiAssistants.run(store, electronApi, updatedChatHistory);
 
     try {
       const response = await electronApi.chatCompletionsCreate(
-        updatedChatHistory
+        updatedAssistedChatHistory
       );
 
       if (response.choices && response.choices.length > 0) {
@@ -51,7 +51,7 @@ export const useAIAssistant = (store: UseStoreType, electronApi: ElectronAPI) =>
           if (parsedResponse.bash_command && parsedResponse.text_response) {
             store.setInputCommand(parsedResponse.bash_command);
             store.setChatHistory([
-              ...updatedChatHistory,
+              ...updatedAssistedChatHistory,
               { role: "assistant", content: assistantResponse },
             ]);
             console.log("Assistant's response:", parsedResponse.text_response);


### PR DESCRIPTION
Related to #8

Refactor `AiAssistants.run` to return `ChatCompletionMessageParam[]` instead of modifying `updatedChatHistory` directly.

* **src/AiAssistants.ts**
  - Modify `AiAssistants.run` to return a `ChatCompletionMessageParam[]`.
  - Update the function signature and implementation to reflect the return type.
* **src/ai-assistants/postgresAssistant.ts**
  - Modify `postgresAssistant` to return a `ChatCompletionMessageParam[]`.
  - Update the function signature and implementation to reflect the return type.
* **src/useAIAssistant.ts**
  - Update the call to `AiAssistants.run` to use the returned chat history.
  - Adjust the function implementation to handle the returned chat history.
* **src/ai-assistants/postgresAssistant.test.ts**
  - Update tests to reflect the changes in `postgresAssistant`.
  - Adjust the test cases to handle the returned chat history.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/williamcotton/guish/issues/8?shareId=276841fd-2fe9-4709-95f9-d460dac43dbd).